### PR TITLE
Remove network state

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,7 +153,7 @@ In HD wallets, chain codes are the mathematical glue that binds a parent node to
 You don't need to worry about chain codes if you are creating or importing from a Master key (it's always the same for all HD wallet master keys), however if you are trying to import a derived child key at some lower depth in the tree, you'll need the chain code. Luckily, whenever we export a node to a wallet file, we encode it in a special format that includes all of the relevant info (including chain code) that we need to reconstruct the node in a single convenient serialized address.
 
 #### Serialized Addresses
-Beacause we need multiple pieces of info to reconstruct nodes in a tree, when we're dealing with HD wallets, we pass around a serialized address format that encodes both the key and the chain code. It looks like this:
+Because we need multiple pieces of info to reconstruct nodes in a tree, when we're dealing with HD wallets, we pass around a serialized address format that encodes both the key and the chain code. It looks like this:
 
 ```ruby
 # private key

--- a/lib/money-tree/address.rb
+++ b/lib/money-tree/address.rb
@@ -8,8 +8,8 @@ module MoneyTree
       @public_key = MoneyTree::PublicKey.new(@private_key, opts)
     end
     
-    def to_s
-      public_key.to_s
+    def to_s(network: :bitcoin)
+      public_key.to_s(network: network)
     end
 
   end

--- a/lib/money-tree/key.rb
+++ b/lib/money-tree/key.rb
@@ -198,6 +198,9 @@ module MoneyTree
         @group = PKey::EC::Group.new GROUP_NAME
         @key = parse_raw_key
       end
+
+      @options[:network] = @network_key # remember for deep clone
+
       raise ArgumentError, "Must initialize with a MoneyTree::PrivateKey or a public key value" if @key.nil?
     end
     

--- a/lib/money-tree/networks.rb
+++ b/lib/money-tree/networks.rb
@@ -1,28 +1,33 @@
 module MoneyTree
-  NETWORKS = {
-    bitcoin: {
-      address_version: '00',
-      p2sh_version: '05',
-      p2sh_char: '3',
-      privkey_version: '80',
-      privkey_compression_flag: '01',
-      extended_privkey_version: "0488ade4",
-      extended_pubkey_version: "0488b21e",
-      compressed_wif_chars: %w(K L),
-      uncompressed_wif_chars: %w(5),
-      protocol_version: 70001
-    },
-    bitcoin_testnet: {
-      address_version: '6f',
-      p2sh_version: 'c4',
-      p2sh_char: '2',
-      privkey_version: 'ef',
-      privkey_compression_flag: '01',
-      extended_privkey_version: "04358394",
-      extended_pubkey_version: "043587cf",
-      compressed_wif_chars: %w(c),
-      uncompressed_wif_chars: %w(9),
-      protocol_version: 70001
-    }
-  }
+  NETWORKS = 
+    begin 
+      Hash.new do |_, key|
+        raise "#{key} is not a valid network!"
+      end.merge({
+        bitcoin: {
+          address_version: '00',
+          p2sh_version: '05',
+          p2sh_char: '3',
+          privkey_version: '80',
+          privkey_compression_flag: '01',
+          extended_privkey_version: "0488ade4",
+          extended_pubkey_version: "0488b21e",
+          compressed_wif_chars: %w(K L),
+          uncompressed_wif_chars: %w(5),
+          protocol_version: 70001
+        },
+        bitcoin_testnet: {
+          address_version: '6f',
+          p2sh_version: 'c4',
+          p2sh_char: '2',
+          privkey_version: 'ef',
+          privkey_compression_flag: '01',
+          extended_privkey_version: "04358394",
+          extended_pubkey_version: "043587cf",
+          compressed_wif_chars: %w(c),
+          uncompressed_wif_chars: %w(9),
+          protocol_version: 70001
+        }
+      })
+    end
 end

--- a/lib/money-tree/node.rb
+++ b/lib/money-tree/node.rb
@@ -3,7 +3,7 @@ module MoneyTree
     include Support
     extend Support
     attr_reader :private_key, :public_key, :chain_code, 
-      :is_private, :depth, :index, :parent, :network, :network_key
+      :is_private, :depth, :index, :parent 
     
     class PublicDerivationFailure < Exception; end
     class InvalidKeyForIndex < Exception; end
@@ -11,49 +11,40 @@ module MoneyTree
     class PrivatePublicMismatch < Exception; end
     
     def initialize(opts = {})
-      @network_key = opts.delete(:network) || :bitcoin
-      @network = MoneyTree::NETWORKS[network_key]
       opts.each { |k, v| instance_variable_set "@#{k}", v }
     end
-    
-    def self.from_serialized_address(address)
+
+    def self.from_wif(address, has_version: true) 
       hex = from_serialized_base58 address
-      version = from_version_hex hex.slice!(0..7)
+      hex.slice!(0..7) if has_version
       self.new({
         depth: hex.slice!(0..1).to_i(16),
         parent_fingerprint: hex.slice!(0..7),
         index: hex.slice!(0..7).to_i(16),
         chain_code: hex.slice!(0..63).to_i(16)
-      }.merge(key_options(hex, version)))
+      }.merge(parse_out_key(hex)))
     end
-    
-    def self.key_options(hex, version)
-      k_opts = { network: version[:network] }
-      if version[:private_key] && hex.slice(0..1) == '00'
-        private_key = MoneyTree::PrivateKey.new({ key: hex.slice(2..-1) }.merge(k_opts))
-        k_opts.merge private_key: private_key, public_key: MoneyTree::PublicKey.new(private_key)
+
+    def self.from_serialized_address(address)
+      puts "Node.from_serialized_address is DEPRECATED.\n
+            Please use .from_wif instead."
+      from_wif(address)
+    end
+
+    def self.parse_out_key(hex)
+      if hex.slice(0..1) == '00'
+        private_key = MoneyTree::PrivateKey.new(key: hex.slice(2..-1))
+        { 
+          private_key: private_key,
+          public_key: MoneyTree::PublicKey.new(private_key) 
+        }
       elsif %w(02 03).include? hex.slice(0..1)
-        k_opts.merge public_key: MoneyTree::PublicKey.new(hex, k_opts)
+        { public_key: MoneyTree::PublicKey.new(hex) }
       else
         raise ImportError, 'Public or private key data does not match version type'
       end
     end
-    
-    def self.from_version_hex(hex)
-      case hex
-      when MoneyTree::NETWORKS[:bitcoin][:extended_privkey_version]
-        { private_key: true, network: :bitcoin }
-      when MoneyTree::NETWORKS[:bitcoin][:extended_pubkey_version]
-        { private_key: false, network: :bitcoin }
-      when MoneyTree::NETWORKS[:bitcoin_testnet][:extended_privkey_version]
-        { private_key: true, network: :bitcoin_testnet }
-      when MoneyTree::NETWORKS[:bitcoin_testnet][:extended_pubkey_version]
-        { private_key: false, network: :bitcoin_testnet }
-      else 
-        raise ImportError, 'invalid version bytes'
-      end
-    end
-    
+
     def is_private?
       index >= 0x80000000 || index < 0
     end
@@ -114,10 +105,10 @@ module MoneyTree
       bytes_to_int hash.bytes.to_a[32..-1]
     end
 
-    def to_serialized_hex(type = :public)
+    def to_serialized_hex(type = :public, network: :bitcoin)
       raise PrivatePublicMismatch if type.to_sym == :private && private_key.nil?
       version_key = type.to_sym == :private ? :extended_privkey_version : :extended_pubkey_version
-      hex = network[version_key] # version (4 bytes)
+      hex = NETWORKS[network][version_key] # version (4 bytes)
       hex += depth_hex(depth) # depth (1 byte)
       hex += parent_fingerprint # fingerprint of key (4 bytes)
       hex += index_hex(index) # child number i (4 bytes)
@@ -125,9 +116,9 @@ module MoneyTree
       hex += type.to_sym == :private ? "00#{private_key.to_hex}" : public_key.compressed.to_hex
     end
     
-    def to_serialized_address(type = :public)
+    def to_serialized_address(type = :public, network: :bitcoin)
       raise PrivatePublicMismatch if type.to_sym == :private && private_key.nil?
-      to_serialized_base58 to_serialized_hex(type)
+      to_serialized_base58 to_serialized_hex(type, network: network)
     end
 
     def to_identifier(compressed=true)
@@ -147,28 +138,27 @@ module MoneyTree
       end
     end
 
-    def to_address(compressed=true)
-      address = network[:address_version] + to_identifier(compressed)
+    def to_address(compressed=true, network: :bitcoin)
+      address = NETWORKS[network][:address_version] + to_identifier(compressed)
       to_serialized_base58 address
     end
     
     def subnode(i = 0, opts = {})
       if private_key.nil?
         child_public_key, child_chain_code = derive_public_key(i)
-        child_public_key = MoneyTree::PublicKey.new child_public_key, network: network_key
+        child_public_key = MoneyTree::PublicKey.new child_public_key
       else
         child_private_key, child_chain_code = derive_private_key(i)
-        child_private_key = MoneyTree::PrivateKey.new key: child_private_key, network: network_key
+        child_private_key = MoneyTree::PrivateKey.new key: child_private_key
         child_public_key = MoneyTree::PublicKey.new child_private_key
       end
             
-      MoneyTree::Node.new network: network_key,
-                          depth: depth+1, 
+      MoneyTree::Node.new( depth: depth+1, 
                           index: i, 
                           private_key: private_key.nil? ? nil : child_private_key,
                           public_key: child_public_key,
                           chain_code: child_chain_code,
-                          parent: self
+                          parent: self)
     end
     
     # path: a path of subkeys denoted by numbers and slashes. Use
@@ -246,8 +236,6 @@ module MoneyTree
       @depth = 0
       @index = 0
       opts[:seed] = [opts[:seed_hex]].pack("H*") if opts[:seed_hex]
-      @network_key = opts[:network] || :bitcoin
-      @network = MoneyTree::NETWORKS[network_key]
       if opts[:seed]
         @seed = opts[:seed]
         @seed_hash = generate_seed_hash(@seed)
@@ -258,14 +246,12 @@ module MoneyTree
         @chain_code = opts[:chain_code]
         if opts[:private_key]
           @private_key = opts[:private_key]
-          @network_key = @private_key.network_key
-          @network = MoneyTree::NETWORKS[network_key]
           @public_key = MoneyTree::PublicKey.new @private_key
         else opts[:public_key]
           @public_key = if opts[:public_key].is_a?(MoneyTree::PublicKey)
             opts[:public_key]
           else
-            MoneyTree::PublicKey.new(opts[:public_key], network: network_key)
+            MoneyTree::PublicKey.new(opts[:public_key])
           end
         end
       else
@@ -295,7 +281,7 @@ module MoneyTree
     end
     
     def set_seeded_keys
-      @private_key = MoneyTree::PrivateKey.new key: left_from_hash(seed_hash), network: network_key
+      @private_key = MoneyTree::PrivateKey.new key: left_from_hash(seed_hash)
       @chain_code = right_from_hash(seed_hash)
       @public_key = MoneyTree::PublicKey.new @private_key
     end

--- a/lib/money-tree/node.rb
+++ b/lib/money-tree/node.rb
@@ -129,9 +129,10 @@ module MoneyTree
       raise PrivatePublicMismatch if type.to_sym == :private && private_key.nil?
       to_serialized_base58 to_serialized_hex(type)
     end
-    
-    def to_identifier
-      public_key.compressed.to_ripemd160
+
+    def to_identifier(compressed=true)
+      key = compressed ? public_key.compressed : public_key.uncompressed
+      key.to_ripemd160
     end
     
     def to_fingerprint
@@ -146,8 +147,8 @@ module MoneyTree
       end
     end
 
-    def to_address
-      address = network[:address_version] + to_identifier
+    def to_address(compressed=true)
+      address = network[:address_version] + to_identifier(compressed)
       to_serialized_base58 address
     end
     

--- a/lib/money-tree/node.rb
+++ b/lib/money-tree/node.rb
@@ -84,7 +84,7 @@ module MoneyTree
     
     def derive_private_key(i = 0)
       message = i >= 0x80000000 || i < 0 ? private_derivation_message(i) : public_derivation_message(i)
-      hash = hmac_sha512 int_to_bytes(chain_code), message
+      hash = hmac_sha512 hex_to_bytes(chain_code_hex), message
       left_int = left_from_hash(hash)
       raise InvalidKeyForIndex, 'greater than or equal to order' if left_int >= MoneyTree::Key::ORDER # very low probability
       child_private_key = (left_int + private_key.to_i) % MoneyTree::Key::ORDER
@@ -96,7 +96,7 @@ module MoneyTree
     def derive_public_key(i = 0)
       raise PrivatePublicMismatch if i >= 0x80000000
       message = public_derivation_message(i)
-      hash = hmac_sha512 int_to_bytes(chain_code), message
+      hash = hmac_sha512 hex_to_bytes(chain_code_hex), message
       left_int = left_from_hash(hash)
       raise InvalidKeyForIndex, 'greater than or equal to order' if left_int >= MoneyTree::Key::ORDER # very low probability
       factor = BN.new left_int.to_s

--- a/lib/money-tree/version.rb
+++ b/lib/money-tree/version.rb
@@ -1,3 +1,3 @@
 module MoneyTree
-  VERSION = "0.8.8"
+  VERSION = "0.8.9"
 end

--- a/lib/openssl_extensions.rb
+++ b/lib/openssl_extensions.rb
@@ -40,6 +40,12 @@ module MoneyTree
       EC_POINT_clear_free(point_0_pt)
       EC_POINT_clear_free(point_1_pt)
 
+      eckey = nil
+      group = nil
+      sum_point = nil
+      point_0_pt = nil
+      point_1_pt = nil
+
       hex
     end
 

--- a/lib/openssl_extensions.rb
+++ b/lib/openssl_extensions.rb
@@ -15,6 +15,7 @@ module MoneyTree
     attach_function :EC_KEY_free, [:pointer], :int
     attach_function :EC_KEY_get0_group, [:pointer], :pointer
     attach_function :EC_KEY_new_by_curve_name, [:int], :pointer
+    attach_function :EC_GROUP_clear_free, [:pointer], :int
     attach_function :EC_POINT_clear_free, [:pointer], :int
     attach_function :EC_POINT_add, [:pointer, :pointer, :pointer, :pointer, :pointer], :int
     attach_function :EC_POINT_point2hex, [:pointer, :pointer, :int, :pointer], :string
@@ -39,6 +40,7 @@ module MoneyTree
       EC_POINT_clear_free(sum_point)
       EC_POINT_clear_free(point_0_pt)
       EC_POINT_clear_free(point_1_pt)
+      EC_GROUP_clear_free(group)
 
       hex
     end

--- a/lib/openssl_extensions.rb
+++ b/lib/openssl_extensions.rb
@@ -15,7 +15,6 @@ module MoneyTree
     attach_function :EC_KEY_free, [:pointer], :int
     attach_function :EC_KEY_get0_group, [:pointer], :pointer
     attach_function :EC_KEY_new_by_curve_name, [:int], :pointer
-    attach_function :EC_GROUP_clear_free, [:pointer], :int
     attach_function :EC_POINT_clear_free, [:pointer], :int
     attach_function :EC_POINT_add, [:pointer, :pointer, :pointer, :pointer, :pointer], :int
     attach_function :EC_POINT_point2hex, [:pointer, :pointer, :int, :pointer], :string
@@ -40,7 +39,6 @@ module MoneyTree
       EC_POINT_clear_free(sum_point)
       EC_POINT_clear_free(point_0_pt)
       EC_POINT_clear_free(point_1_pt)
-      EC_GROUP_clear_free(group)
 
       hex
     end

--- a/spec/lib/money-tree/address_spec.rb
+++ b/spec/lib/money-tree/address_spec.rb
@@ -56,7 +56,7 @@ describe MoneyTree::Address do
     end
 
     it "returns a testnet address" do
-      expect(%w(m n)).to include(@address.to_s[0])
+      expect(%w(m n)).to include(@address.to_s(network: :bitcoin_testnet)[0])
     end
   end
 end

--- a/spec/lib/money-tree/node_spec.rb
+++ b/spec/lib/money-tree/node_spec.rb
@@ -793,5 +793,15 @@ describe MoneyTree::Master do
         end
       end
     end
+
+    describe "deriving a child node" do
+      describe "#node_for_path" do
+        it "correctly derives from a node with a chain code represented in 31 bytes" do
+          @node = MoneyTree::Node.from_serialized_address "tpubD6NzVbkrYhZ4WM42MZZmUZ7LjxyjBf5bGjEeLf9nJnMZqocGJWu94drvpqWsE9jE7k3h22v6gjpPGnqgBrqwGsRYwDXVRfQ2M9dfHbXP5zA"
+          @subnode = @node.node_for_path('m/1')
+          expect(@subnode.to_serialized_address).to eql("tpubDA7bCxb3Nrcz2ChXyPqXxbG4q5oiAZUHR7wD3LAiXukuxmT65weWw84XYmjhkJTkJEM6LhNWioWTpKEkQp7j2fgVccj3PPc271xHDeMsaTY")
+        end
+      end
+    end
   end
 end

--- a/spec/lib/money-tree/node_spec.rb
+++ b/spec/lib/money-tree/node_spec.rb
@@ -423,7 +423,13 @@ describe MoneyTree::Master do
             expect(@master.to_fingerprint).to eql("bd16bee5")
             expect(@master.to_address).to eql("1JEoxevbLLG8cVqeoGKQiAwoWbNYSUyYjg")
           end
-      
+
+          it "generates compressed and uncompressed addresses" do
+            expect(@master.to_address).to eql("1JEoxevbLLG8cVqeoGKQiAwoWbNYSUyYjg")
+            expect(@master.to_address(true)).to eql("1JEoxevbLLG8cVqeoGKQiAwoWbNYSUyYjg")
+            expect(@master.to_address(false)).to eql("1AEg9dFEw29kMgaN4BNHALu7AzX5XUfzSU")
+          end
+
           it "generates a secret key" do
             expect(@master.private_key.to_hex).to eql("4b03d6fc340455b363f51020ad3ecca4f0850280cf436c70c727923f6db46c3e")
             expect(@master.private_key.to_wif).to eql("KyjXhyHF9wTphBkfpxjL8hkDXDUSbE3tKANT94kXSyh6vn6nKaoy")

--- a/spec/lib/money-tree/node_spec.rb
+++ b/spec/lib/money-tree/node_spec.rb
@@ -24,49 +24,49 @@ describe MoneyTree::Master do
       end
 
       it "generates testnet address" do
-        expect(%w(m n)).to include(@master.to_address[0])
+        expect(%w(m n)).to include(@master.to_address(network: :bitcoin_testnet)[0])
       end
 
       it "generates testnet compressed wif" do
-        expect(@master.private_key.to_wif[0]).to eql('c')
+        expect(@master.private_key.to_wif(network: :bitcoin_testnet)[0]).to eql('c')
       end
 
       it "generates testnet uncompressed wif" do
-        expect(@master.private_key.to_wif(compressed: false)[0]).to eql('9')
+        expect(@master.private_key.to_wif(compressed: false, network: :bitcoin_testnet)[0]).to eql('9')
       end
 
       it "generates testnet serialized private address" do
-        expect(@master.to_serialized_address(:private).slice(0, 4)).to eql("tprv")
+        expect(@master.to_serialized_address(:private, network: :bitcoin_testnet).slice(0, 4)).to eql("tprv")
       end
 
       it "generates testnet serialized public address" do
-        expect(@master.to_serialized_address.slice(0, 4)).to eql("tpub")
+        expect(@master.to_serialized_address(network: :bitcoin_testnet).slice(0, 4)).to eql("tpub")
       end
 
       it "imports from testnet serialized private address" do
         node = MoneyTree::Node.from_serialized_address 'tprv8ZgxMBicQKsPcuN7bfUZqq78UEYapr3Tzmc9NcDXw8BnBJ47dZYr6SusnfYj7vbAYP9CP8ZiD5aVBTUo1yU5QP56mepKVvuEbu8KZQXMKNE'
-        expect(node.to_serialized_address(:private)).to eql('tprv8ZgxMBicQKsPcuN7bfUZqq78UEYapr3Tzmc9NcDXw8BnBJ47dZYr6SusnfYj7vbAYP9CP8ZiD5aVBTUo1yU5QP56mepKVvuEbu8KZQXMKNE')
+        expect(node.to_serialized_address(:private, network: :bitcoin_testnet)).to eql('tprv8ZgxMBicQKsPcuN7bfUZqq78UEYapr3Tzmc9NcDXw8BnBJ47dZYr6SusnfYj7vbAYP9CP8ZiD5aVBTUo1yU5QP56mepKVvuEbu8KZQXMKNE')
       end
 
       it "imports from testnet serialized public address" do
         node = MoneyTree::Node.from_serialized_address 'tpubD6NzVbkrYhZ4YA8aUE9bBZTSyHJibBqwDny5urfwDdJc4W8od3y3Ebzy6CqsYn9CCC5P5VQ7CeZYpnT1kX3RPVPysU2rFRvYSj8BCoYYNqT'
-        expect(%w(m n)).to include(node.public_key.to_s[0])
-        expect(node.to_serialized_address).to eql('tpubD6NzVbkrYhZ4YA8aUE9bBZTSyHJibBqwDny5urfwDdJc4W8od3y3Ebzy6CqsYn9CCC5P5VQ7CeZYpnT1kX3RPVPysU2rFRvYSj8BCoYYNqT')
+        expect(%w(m n)).to include(node.public_key.to_s(network: :bitcoin_testnet)[0])
+        expect(node.to_serialized_address(network: :bitcoin_testnet)).to eql('tpubD6NzVbkrYhZ4YA8aUE9bBZTSyHJibBqwDny5urfwDdJc4W8od3y3Ebzy6CqsYn9CCC5P5VQ7CeZYpnT1kX3RPVPysU2rFRvYSj8BCoYYNqT')
       end
 
       it "generates testnet subnodes from serialized private address" do
         node = MoneyTree::Node.from_serialized_address 'tprv8ZgxMBicQKsPcuN7bfUZqq78UEYapr3Tzmc9NcDXw8BnBJ47dZYr6SusnfYj7vbAYP9CP8ZiD5aVBTUo1yU5QP56mepKVvuEbu8KZQXMKNE'
         subnode = node.node_for_path('1/1/1')
-        expect(%w(m n)).to include(subnode.public_key.to_s[0])
-        expect(subnode.to_serialized_address(:private).slice(0,4)).to eql('tprv')
-        expect(subnode.to_serialized_address.slice(0,4)).to eql('tpub')
+        expect(%w(m n)).to include(subnode.public_key.to_s(network: :bitcoin_testnet)[0])
+        expect(subnode.to_serialized_address(:private, network: :bitcoin_testnet).slice(0,4)).to eql('tprv')
+        expect(subnode.to_serialized_address(network: :bitcoin_testnet).slice(0,4)).to eql('tpub')
       end
 
       it "generates testnet subnodes from serialized public address" do
         node = MoneyTree::Node.from_serialized_address 'tpubD6NzVbkrYhZ4YA8aUE9bBZTSyHJibBqwDny5urfwDdJc4W8od3y3Ebzy6CqsYn9CCC5P5VQ7CeZYpnT1kX3RPVPysU2rFRvYSj8BCoYYNqT'
         subnode = node.node_for_path('1/1/1')
-        expect(%w(m n)).to include(subnode.public_key.to_s[0])
-        expect(subnode.to_serialized_address.slice(0,4)).to eql('tpub')
+        expect(%w(m n)).to include(subnode.public_key.to_s(network: :bitcoin_testnet)[0])
+        expect(subnode.to_serialized_address(network: :bitcoin_testnet).slice(0,4)).to eql('tpub')
       end
     end
 
@@ -799,7 +799,7 @@ describe MoneyTree::Master do
         it "correctly derives from a node with a chain code represented in 31 bytes" do
           @node = MoneyTree::Node.from_serialized_address "tpubD6NzVbkrYhZ4WM42MZZmUZ7LjxyjBf5bGjEeLf9nJnMZqocGJWu94drvpqWsE9jE7k3h22v6gjpPGnqgBrqwGsRYwDXVRfQ2M9dfHbXP5zA"
           @subnode = @node.node_for_path('m/1')
-          expect(@subnode.to_serialized_address).to eql("tpubDA7bCxb3Nrcz2ChXyPqXxbG4q5oiAZUHR7wD3LAiXukuxmT65weWw84XYmjhkJTkJEM6LhNWioWTpKEkQp7j2fgVccj3PPc271xHDeMsaTY")
+          expect(@subnode.to_serialized_address(network: :bitcoin_testnet)).to eql("tpubDA7bCxb3Nrcz2ChXyPqXxbG4q5oiAZUHR7wD3LAiXukuxmT65weWw84XYmjhkJTkJEM6LhNWioWTpKEkQp7j2fgVccj3PPc271xHDeMsaTY")
         end
       end
     end

--- a/spec/lib/money-tree/private_key_spec.rb
+++ b/spec/lib/money-tree/private_key_spec.rb
@@ -45,7 +45,7 @@ describe MoneyTree::PrivateKey do
     end
     
     it "is valid" do
-      expect(@key.to_wif(compressed: false)).to eql('5JXz5ZyFk31oHVTQxqce7yitCmTAPxBqeGQ4b7H3Aj3L45wUhoa'      )
+      expect(@key.to_wif(compressed: false)).to eql('5JXz5ZyFk31oHVTQxqce7yitCmTAPxBqeGQ4b7H3Aj3L45wUhoa')
     end
   end
   
@@ -104,7 +104,7 @@ describe MoneyTree::PrivateKey do
 
     describe "to_wif" do
       it "returns same wif" do
-        expect(@key.to_wif).to eql('cRhes8SBnsF6WizphaRKQKZZfDniDa9Bxcw31yKeEC1KDExhxFgD')
+        expect(@key.to_wif(network: :bitcoin_testnet)).to eql('cRhes8SBnsF6WizphaRKQKZZfDniDa9Bxcw31yKeEC1KDExhxFgD')
       end
     end
   end

--- a/spec/lib/money-tree/public_key_spec.rb
+++ b/spec/lib/money-tree/public_key_spec.rb
@@ -161,26 +161,26 @@ describe MoneyTree::PublicKey do
   context "testnet" do
     context 'with private key' do
       before do
-        @private_key = MoneyTree::PrivateKey.new network: :bitcoin_testnet
+        @private_key = MoneyTree::PrivateKey.new
         @key = MoneyTree::PublicKey.new(@private_key)
       end
 
       it "should have an address starting with m or n" do
-        expect(%w(m n)).to include(@key.to_s[0])
+        expect(%w(m n)).to include(@key.to_s(network: :bitcoin_testnet)[0])
       end
 
       it "should have an uncompressed address starting with m or n" do
-        expect(%w(m n)).to include(@key.uncompressed.to_s[0])
+        expect(%w(m n)).to include(@key.uncompressed.to_s(network: :bitcoin_testnet)[0])
       end
     end
 
     context 'without private key' do
       before do
-        @key = MoneyTree::PublicKey.new('0297b033ba894611345a0e777861237ef1632370fbd58ebe644eb9f3714e8fe2bc', network: :bitcoin_testnet)
+        @key = MoneyTree::PublicKey.new('0297b033ba894611345a0e777861237ef1632370fbd58ebe644eb9f3714e8fe2bc')
       end
 
       it "should have an address starting with m or n" do
-        expect(%w(m n)).to include(@key.to_s[0])
+        expect(%w(m n)).to include(@key.to_s(network: :bitcoin_testnet)[0])
       end
     end
   end

--- a/spec/lib/money-tree/public_key_spec.rb
+++ b/spec/lib/money-tree/public_key_spec.rb
@@ -168,6 +168,10 @@ describe MoneyTree::PublicKey do
       it "should have an address starting with m or n" do
         expect(%w(m n)).to include(@key.to_s[0])
       end
+
+      it "should have an uncompressed address starting with m or n" do
+        expect(%w(m n)).to include(@key.uncompressed.to_s[0])
+      end
     end
 
     context 'without private key' do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,2 +1,3 @@
 require 'simplecov'
 require 'money-tree'
+require 'pry'


### PR DESCRIPTION
Money-Tree, in essence is a key-derivation tool.
The keys it derives are not aware of the 'coin',
or 'version'. So there is now no notion of network
held as state on anything.

Money-Tree derives keys, and in the various forms of serialization
you can specify which type of coin (version bytes) you'd like to use.

Although it may seem tedious, it allows trees to be
coin-agnostic until serialization (and theoretically
the usage of the same key-pairs for different coin
addresses.)
